### PR TITLE
delete spaces after newline escape

### DIFF
--- a/source/_guides/01-authentication.md
+++ b/source/_guides/01-authentication.md
@@ -27,11 +27,11 @@ All you need to do is get the API key and follow the instructions of the library
 To authenticate, put the API key to  the `Api-Key` header, eg:
 
 ```language-bash
-curl -H 'Content-Type: application/json' \  
+curl -H 'Content-Type: application/json' \
  -H 'Api-Version: 1' \
- -H 'Api-Key: myKey' \ 
+ -H 'Api-Key: myKey' \
  -X GET \
- 'https://api.rokka.io/{action}' 
+ 'https://api.rokka.io/{action}'
 ```
 
 ### Format of API Keys
@@ -59,8 +59,8 @@ It will be authenticated as the same user as with that API key.
 
 [Try it out](https://api.rokka.io/doc/#/admin/getUserToken)
 ```language-bash
-curl -H 'Content-Type: application/json' \ 
- -H 'Api-Version: 1' \ 
+curl -H 'Content-Type: application/json' \
+ -H 'Api-Version: 1' \
  -H 'Api-Key: myKey' \
  'https://api.rokka.io/user/apikeys/token'
 ```
@@ -111,9 +111,9 @@ generate a token in the backend from an API Key with less permissions and send i
 After you get the token, you send the token prefixed with `Bearer ` in the `Authorization` header.
 
 ```language-bash
-curl -H 'Content-Type: application/json' \ 
- -H 'Api-Version: 1' \ 
- -H 'Authorization: Bearer $TOKEN' \ 
+curl -H 'Content-Type: application/json' \
+ -H 'Api-Version: 1' \
+ -H 'Authorization: Bearer $TOKEN' \
  'https://api.rokka.io/user/apikeys/current'
 ```
 

--- a/source/_references/00-sourceimages.md
+++ b/source/_references/00-sourceimages.md
@@ -63,7 +63,7 @@ downloaded by rokka and inserted into your repository. This happens synchronousl
 The image at the URL has to be publicly accessible. There's currently no way to add authentication. If you need that, [talk to us](https://rokka.io/en/contact/).
 
 ```language-bash
-curl -X POST \ 
+curl -X POST \
 -F url[0]='https://rokka.rokka.io/dynamic/noop/f4d3f334ba90d2b4b00e82953fe0bf93e7ad9912.png' \
 'https://api.rokka.io/sourceimages/mycompany'
 ```
@@ -338,7 +338,7 @@ If an image is locked, no one can delete an image before it's not unlocked, not 
 
 Bash:
 ```language-bash
-curl -X PUT 'https://api.rokka.io/sourceimages/mycompany/0dcabb778d58d07ccd48b5ff291de05ba4374fb9/options/protected' \ 
+curl -X PUT 'https://api.rokka.io/sourceimages/mycompany/0dcabb778d58d07ccd48b5ff291de05ba4374fb9/options/protected' \
       --data-raw 'true'
 ```
 

--- a/source/_references/45-protected-images-stacks.md
+++ b/source/_references/45-protected-images-stacks.md
@@ -48,8 +48,8 @@ To mark an image as protected during upload, you set the `protected` property in
 
 Bash:
 ```language-bash
-curl -X POST -F filedata=@image.png \ 
-     'https://api.rokka.io/sourceimages/mycompany' \ 
+curl -X POST -F filedata=@image.png \
+     'https://api.rokka.io/sourceimages/mycompany' \
      --form 'options[]={"protected":true}'
 ```
 PHP:
@@ -86,7 +86,7 @@ The new hash is reported in the `Location` header field.
 
 Bash:
 ```language-bash
-curl -X PUT 'https://api.rokka.io/sourceimages/mycompany/0dcabb778d58d07ccd48b5ff291de05ba4374fb9/options/protected' \ 
+curl -X PUT 'https://api.rokka.io/sourceimages/mycompany/0dcabb778d58d07ccd48b5ff291de05ba4374fb9/options/protected' \
       --data-raw 'true'
 ```
 
@@ -196,7 +196,7 @@ The examples to set this organization option:
 
 Bash:
 ```language-bash
-curl -X PUT 'https://api.rokka.io/organizations/mycompany/options/protect_dynamic_stack' \ 
+curl -X PUT 'https://api.rokka.io/organizations/mycompany/options/protect_dynamic_stack' \
       --data-raw 'true'
 ```
 


### PR DESCRIPTION
I got some errors after copy & past of the curl examples because of a space after the escape for the newline. I guess that will fix it.